### PR TITLE
Add an option to set prettier module path

### DIFF
--- a/prettier.el
+++ b/prettier.el
@@ -238,6 +238,14 @@ Set this variable to nil to disable the mode line completely."
                  (prettier--readme-link
                   "prettier-lighter"))))
 
+(defcustom prettier-module-path nil
+  "The module to load instead of the bundled or global prettier.
+
+The value must be an absolute path."
+  :type '(choice (const nil) string)
+  :group 'prettier
+  :risky t)
+
 (defface prettier-inline-error
   '((t :inherit compilation-error))
   "Prettier face for errors."
@@ -794,6 +802,7 @@ otherwise, launch a new one."
                   "w"
                   (if prettier-editorconfig-flag "E" "e")
                   (prettier--local-file-name)
+                  "\n" (or prettier-module-path "-")
                   "\n\n")
                  t))
               process)
@@ -1014,6 +1023,7 @@ Don't touch variables that have changed since config was synced."
                       (if prettier-editorconfig-flag "E" "e")
                       (if prettier-infer-parser-flag "I" "i")
                       (prettier--local-file-name)
+                      "\n" (or prettier-module-path "-")
                       "\n" (if parsers (string-join
                                         (mapcar #'symbol-name parsers)
                                         ",")
@@ -1098,6 +1108,7 @@ formatting."
                  (if prettier-editorconfig-flag "E" "e")
                  (if prettier-infer-parser-flag "I" "i")
                  filename
+                 "\n" (or prettier-module-path "-")
                  "\n" (if parsers
                           (string-join
                            (mapcar #'symbol-name parsers)


### PR DESCRIPTION
Yarn switched thier package management to [Plug'n'Play](https://yarnpkg.com/features/pnp) style in Yarn berry and this change breaks our searching method for Prettier because there are no longer `node_modules` directories.

One possible fix for this, I'd like to add a `prettier-module-path` option to use [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) for Prettier they have provided as described below.
```el
(setq-local prettier-module-path (expand-file-name "~/.vscode/pnpify/prettier"))
```