### PR TITLE
Suppress console.warn output

### DIFF
--- a/prettier-el.js
+++ b/prettier-el.js
@@ -17,6 +17,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Hack to prevent Yarn 2.x from logging warnings to stderr.
+function noop() {}
+global["console"]["warn"] = noop;
+
 // Hack to circumvent Closure Compiler CommonJS resolution
 const externalRequire = require;
 


### PR DESCRIPTION
We have no meaningful way of handling warnings anyway.  I've briefly considered forwarding them to Emacs and showing them there, but it doesn't seem like something users should be concerned with. The warning mentioned in the ticket is the first one I've come across so far and it is not a useful piece of information in our use case.

Closes #64