### PR TITLE
Restart Prettier on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ be able to set/override the Prettier parser to use for formatting.
 
 ### Changing Prettier Configuration
 
-After you change Prettier options (by creating, modifying or deleting
-Prettier configuration files), this package won't pick up the changes
-automatically. Disable and re-enable `global-prettier-mode` to force
-reloading the new configuration. This might be improved in the future by
-monitoring relevant files for changes.
+You should run `M-x prettier-restart` whenever any relevant
+configuration changes, such as when you install a new version of Node,
+Prettier, or any plugins; when you install or uninstall Prettier as a
+local npm package in a directory from which you already have files
+open in Emacs; or when you change Prettier settings that might affect
+any open files.  Doing so will clear all caches and ensure that your
+changes are picked up.
 
 ### On Remote Servers
 

--- a/prettier-tests.el
+++ b/prettier-tests.el
@@ -13,10 +13,12 @@
 
 
 (require 'ert)
-(require 'ert-async)
 (require 'noflet)
 (require 'thingatpt)
 (require 'prettier)
+
+(eval-when-compile
+  (require 'ert-async))
 
 (setq prettier-el-home (concat
                         (file-name-directory load-file-name)
@@ -114,20 +116,20 @@
 
 (ert-deftest-async restart-prettier (done)
   (prettier--quit-all-processes)
-    (delay
-     (lambda ()
-       (with-current-buffer (get-buffer-create "test.js")
-         (js-mode)
-         (should (not (any-prettier-process-p)))
-         (prettier-mode)
-         (delay
-          (lambda ()
-            (should (any-prettier-process-p))
-            (prettier-restart)
-            (delay
-             (lambda ()
-               (should (any-prettier-process-p))
-               (funcall done)))))))))
+  (delay
+   (lambda ()
+     (with-current-buffer (get-buffer-create "test.js")
+       (js-mode)
+       (should (not (any-prettier-process-p)))
+       (prettier-mode)
+       (delay
+        (lambda ()
+          (should (any-prettier-process-p))
+          (prettier-restart)
+          (delay
+           (lambda ()
+             (should (any-prettier-process-p))
+             (funcall done)))))))))
 
 (provide 'prettier-tests)
 

--- a/prettier-tests.el
+++ b/prettier-tests.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (c) 2018-present Julian Scheid
 
-;; Package-Requires: ((web-mode "20200501") (elm-mode "20200406") (pug-mode "20180513") (svelte-mode "20200327") (toml-mode "20161107") (solidity-mode "20200418") (vue-mode "20190415") (lsp-mode "20201111") (noflet "20141102") (f "20191110"))
+;; Package-Requires: ((web-mode "20200501") (elm-mode "20200406") (pug-mode "20180513") (svelte-mode "20200327") (toml-mode "20161107") (solidity-mode "20200418") (vue-mode "20190415") (lsp-mode "20201111") (noflet "20141102") (f "20191110") (ert-async "0.1"))
 
 ;;; Commentary:
 
@@ -13,6 +13,7 @@
 
 
 (require 'ert)
+(require 'ert-async)
 (require 'noflet)
 (require 'thingatpt)
 (require 'prettier)
@@ -96,6 +97,37 @@
   (customize-option 'prettier-enabled-parsers)
   (customize-option 'prettier-mode-ignore-buffer-function)
   (customize-option 'prettier-lighter))
+
+(defun prettier-process-p (process)
+  "Return non-nil if PROCESS is like a Prettier process."
+  (and (string-match "^prettier" (process-name process))
+       (process-get process :server-id)
+       (process-live-p process)))
+
+(defun any-prettier-process-p ()
+  "Return non-nil if any process is like a Prettier process."
+  (seq-some #'prettier-process-p (process-list)))
+
+(defun delay (callback)
+  "Call CALLBACK delayed by a little while."
+  (run-at-time 0.5 nil callback))
+
+(ert-deftest-async restart-prettier (done)
+  (prettier--quit-all-processes)
+    (delay
+     (lambda ()
+       (with-current-buffer (get-buffer-create "test.js")
+         (js-mode)
+         (should (not (any-prettier-process-p)))
+         (prettier-mode)
+         (delay
+          (lambda ()
+            (should (any-prettier-process-p))
+            (prettier-restart)
+            (delay
+             (lambda ()
+               (should (any-prettier-process-p))
+               (funcall done)))))))))
 
 (provide 'prettier-tests)
 

--- a/prettier.el
+++ b/prettier.el
@@ -1429,6 +1429,6 @@ parsers configured for it and it is a derived mode."
 
 (provide 'prettier)
 
-;; LocalWords: editorconfig minibuffer minified nvm parsers stdin
+;; LocalWords: editorconfig minibuffer minified nvm parsers stdin npm
 
 ;;; prettier.el ends here

--- a/prettier.el
+++ b/prettier.el
@@ -568,7 +568,34 @@ With prefix, ask for the parser to use"
   (maphash (lambda (_key process)
              (quit-process process))
            prettier-processes)
-  (clrhash prettier-processes))
+  (clrhash prettier-processes)
+  (setq prettier-nvm-node-command-cache nil))
+
+(defun prettier-restart ()
+  "Restart Prettier in all buffers.
+
+This will cause all caches to be cleared and the latest version
+of the sidecar JavaScript file to be used.  It is executed every
+time this package is loaded which is intended to ensure you're
+running the latest when the package is upgraded.
+
+You should run this function whenever any relevant configuration
+changes, such as when you install a new version of Node,
+Prettier, or any plugins; when you install or uninstall Prettier
+as a local npm package in a directory from which you already have
+files open in Emacs; or when you change Prettier settings that
+might affect any open files."
+  (interactive)
+  (prettier--quit-all-processes)
+  (unless (eq prettier-pre-warm 'none)
+    (mapc (lambda (buf)
+            (with-current-buffer buf
+              (when (and (boundp 'prettier-mode)
+                         prettier-mode)
+                (prettier--get-process
+                 (eq prettier-pre-warm 'full)))))
+          (buffer-list)))
+  (message "Prettier restart complete."))
 
 (defun prettier--buffer-remote-p (&optional identification connected)
   "Return `file-remote-p' result for the current buffer.
@@ -683,8 +710,7 @@ should be used when filing bug reports."
  'global-prettier-mode-hook
  (lambda ()
    (unless global-prettier-mode
-     (prettier--quit-all-processes)
-     (setq prettier-nvm-node-command-cache nil))))
+     (prettier--quit-all-processes))))
 
 
 ;;;; Support
@@ -1390,6 +1416,13 @@ parsers configured for it and it is a derived mode."
 (add-to-list 'compilation-error-regexp-alist-alist
              (cons 'prettier prettier-compilation-regexps))
 (add-to-list 'compilation-error-regexp-alist 'prettier)
+
+
+;;;; Ensure we're running latest JavaScript sub-process
+
+;; (On initial load, `prettier-restart' is a no-op.)
+(when load-in-progress
+  (prettier-restart))
 
 
 ;;;; Footer


### PR DESCRIPTION
This is intended to ensure that the version of the JavaScript code running in the child process matches that of the Elisp code.

Also, introduce a new interactive function called prettier-restart that can be used to explicitly restart the system so that configuration changes get picked up.