### PR TITLE
Enable json5 and json-stringify parsers by default (#92)

### DIFF
--- a/prettier.el
+++ b/prettier.el
@@ -153,6 +153,8 @@ Requires Prettier 1.9+."
                                       html
                                       java
                                       json
+                                      json5
+                                      json-stringify
                                       less
                                       lua
                                       markdown


### PR DESCRIPTION
These two parsers were accidentally omitted from the default list.  In particular, this broke the choice of parser for `package.json` files.  So add them to the default list.

This solves the original motivating factor for #92, but not #92 itself which is a request for enhanced debugging capabilities.