### PR TITLE
Upgrade Emacs on CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,9 +42,9 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 26.3
-          - 27.2
-          - 28.1
+          - 27.1
+          - 28.2
+          - 29.1
           - snapshot
     outputs:
       tarball_name: "${{ steps.upload.outputs.tarball_name }}"
@@ -115,14 +115,14 @@ jobs:
           echo "::set-output name=tarball_name::${tarball_name}"
 
       - name: Upload build
-        if: matrix.emacs_version == '26.3'
+        if: matrix.emacs_version == '27.1'
         uses: actions/upload-artifact@v3
         with:
           path: "${{ steps.build.outputs.tarball_name }}"
           name: "${{ steps.build.outputs.tarball_name }}"
 
       - name: Set build output
-        if: matrix.emacs_version == '26.3'
+        if: matrix.emacs_version == '27.1'
         id: upload
         run: |
           echo "::set-output name=tarball_name::${{ steps.build.outputs.tarball_name }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ version 0.9.0 they are now documented in `CHANGELOG.md`.
 
 A tarball is generated for every pull request. It can be downloaded by
 going to the Github pull request page, clicking on "Details" for the
-topmost check (called something like "build (26.3)"), then on
+topmost check (called something like "build (27.1)"), then on
 "Artifacts" and finally on "prettier.tar".
 
 Github currently [insists on wrapping it in a Zip


### PR DESCRIPTION
https://github.com/jscheid/prettier.el/pull/124#issuecomment-1717704749

`lsp-mode` in Mepla is now changed into what requires `emacs-27.1`. Therefore we remove Emacs 26 and add Emacs 29 on CI. The oldest Emacs package we test is changed to 27.1.
