### PR TITLE
Compatibility with newer versions of editorconfig

### DIFF
--- a/prettier.el
+++ b/prettier.el
@@ -7,7 +7,7 @@
 ;; Created: 7 Nov 2018
 ;; Keywords: convenience, languages, files
 ;; Homepage: https://github.com/jscheid/prettier.el
-;; Package-Requires: ((emacs "26.1") (iter2 "0.9") (nvm "0.2") (editorconfig "0.8"))
+;; Package-Requires: ((emacs "26.1") (iter2 "0.9") (nvm "0.2") (editorconfig "0.9"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -1179,12 +1179,19 @@ post-formatting as possible."
           t))
        (prettier--backup-buffer-local-values
         (lambda ()
-          (editorconfig-set-indentation
-           (if (eq (plist-get options :useTabs) t) "tab" "space")
-           (number-to-string (plist-get options :tabWidth))
-           nil)
-          (editorconfig-set-line-length
-           (number-to-string (plist-get options :printWidth)))
+          (let ((props (make-hash-table)))
+            (puthash 'indent_style
+                     (if (eq (plist-get options :useTabs) t)
+                         "tab"
+                       "space")
+                     props)
+            (puthash 'indent_size
+                     (number-to-string (plist-get options :tabWidth))
+                     props)
+            (puthash 'max_line_length
+                     (number-to-string (plist-get options :printWidth))
+                     props)
+            (editorconfig-set-local-variables props))
 
           (mapc (lambda (setting)
                   (let* ((vars (nth 0 setting))


### PR DESCRIPTION
Emacs 30 ships with a new version of the editorconfig package, ensure we're compatible with it.